### PR TITLE
fix: do not render math blocks in code blocks

### DIFF
--- a/lib/mathjax.js
+++ b/lib/mathjax.js
@@ -5,23 +5,36 @@ const debug = false;
 
 let inline_mathjax_regex = null,
   block_mathjax_regex = null,
+  inline_code_regex = null,
+  block_code_regex = null,
   disable = false;
 
 exports.beforeRender = function (data) {
   if (disable) return;
 
+  var block_mathjax_filter_regex = new RegExp('(' + inline_code_regex + ')|(' + block_code_regex + ')|(' + block_mathjax_regex + ')', 'g');
+  var inline_mathjax_filter_regex = new RegExp('(' + inline_code_regex + ')|(' + block_code_regex + ')|(' + inline_mathjax_regex + ')', 'g');
+
   const mathList = [];
 
   data.content = data.content
-    .replace(block_mathjax_regex, function (raw, math) {
-      const marker = getMarker();
-      mathList.push({ math, block: true, marker, raw });
-      return marker;
+    .replace(block_mathjax_filter_regex, function (raw, math) {
+      if ((new RegExp('^' + block_mathjax_regex + '$')).test(raw)) {
+        math = RegExp.$1;
+        const marker = getMarker();
+        mathList.push({ math, block: true, marker, raw });
+        return marker;
+      }
+      return raw;
     })
-    .replace(inline_mathjax_regex, function (raw, math) {
-      const marker = getMarker();
-      mathList.push({ math, marker, raw });
-      return marker;
+    .replace(inline_mathjax_filter_regex, function (raw, math) {
+      if ((new RegExp('^' + inline_mathjax_regex + '$')).test(raw)) {
+        math = RegExp.$1;
+        const marker = getMarker();
+        mathList.push({ math, marker, raw });
+        return marker; 
+      }
+      return raw;
     });
 
   if (mathList.length) {
@@ -72,8 +85,10 @@ exports.config = function (config) {
   const iq = parseTag(config.inlineQuote, '$');
   const bq = parseTag(config.blockQuote, '$$');
 
-  inline_mathjax_regex = new RegExp(raw`${iq[0]}(.+?)${iq[1]}`, 'g');
-  block_mathjax_regex = new RegExp(raw`${bq[0]}\s*([\s\S]+?)\s*${bq[1]}`, 'g');
+  inline_mathjax_regex = raw`${iq[0]}(.+?)${iq[1]}`;
+  block_mathjax_regex = raw`${bq[0]}\s*([\s\S]+?)\s*${bq[1]}`;
+  inline_code_regex = "`[^`\n]+?`"
+  block_code_regex = "(```)[^`](([^]+?)[^`])(```)"
   disable = !!config.disable;
 
   debug && console.log(inline_mathjax_regex, block_mathjax_regex)


### PR DESCRIPTION
As mentioned in #2 , math block in code block will also be rendered. I fix it by matching both code block and math block using regular expression at the meantime and only rendering math block.